### PR TITLE
ENH: IRTAM coefficient download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project are documented in this file. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.0.4 (06-XX-2024)
+* Added a function to retrieve the IRTAM coefficients
+* Added a module for IRTAM coefficient functions
+* Added unit tests for the IRTAM coefficient functions
+
 ## 0.0.3 (03-20-2024)
 * Fixed import bug, changing the name of the primary sub-module
 * Added an error catch for bad IRTAM directory input and unit tests for this

--- a/PyIRTAM/__init__.py
+++ b/PyIRTAM/__init__.py
@@ -1,13 +1,24 @@
 """Core library imports for PyIRTAM."""
 
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
+from importlib import metadata
+from importlib import resources
+
+if not hasattr(resources, 'files'):
+    # The `files` object was introduced in Python 3.9
+    resources = None
+    import os
 
 # Import the package modules and top-level classes
+from PyIRTAM import coeff  # noqa F401
 from PyIRTAM import lib  # noqa F401
 from PyIRTAM.lib import run_PyIRTAM  # noqa F401
 
 # Set version
 __version__ = metadata.version('PyIRTAM')
+
+# Set the package IRTAM coefficient directory
+if resources is None:
+    irtam_coeff_dir = os.path.join(os.path.realpath(os.path.dirname(__file__)),
+                                   'irtam_coeffs')
+else:
+    irtam_coeff_dir = str(resources.files(__package__).joinpath('irtam_coeffs'))

--- a/PyIRTAM/coeff.py
+++ b/PyIRTAM/coeff.py
@@ -56,10 +56,10 @@ def download_irtam_coeffs(dtime, param, irtam_dir='', use_subdirs=True,
         irtam_dir = PyIRTAM.irtam_coeff_dir
 
     # Determine the appropriate output filename
-    param_file = get_irtam_param_filename(dtime, param, irtam_dir)
+    param_file = get_irtam_param_filename(dtime, param, irtam_dir, use_subdirs)
 
     # Ensure the desired output directory exists
-    dir_name, _ = os.path.split(param_file)
+    dir_name = os.path.dirname(param_file)
 
     if not os.path.isdir(dir_name):
         os.makedirs(dir_name)
@@ -70,6 +70,8 @@ def download_irtam_coeffs(dtime, param, irtam_dir='', use_subdirs=True,
         msg = 'IRTAM parameter coefficient file exists: {:}'.format(param_file)
         if not overwrite:
             return dstat, fstat, msg
+        else:
+            msg = "".join(["Overwriting ", msg])
 
     # Construct the query
     base_url = "https://lgdc.uml.edu/rix/gambit-coeffs"

--- a/PyIRTAM/coeff.py
+++ b/PyIRTAM/coeff.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+# --------------------------------------------------------
+"""This module contains functions to obtain and update the IRTAM coefficients.
+
+"""
+import os
+import requests
+
+import PyIRTAM
+
+
+def download_irtam_coeffs(dtime, param, irtam_dir='', use_subdirs=True,
+                          overwrite=False):
+    """Retrieve the IRTAM coefficients from the UMass Lowell GIRO Data Center.
+
+    Parameters
+    ----------
+    dtime : dt.datetime
+        Date and time for the desired coefficents
+    param : str
+        Coefficient parameter to retrieve. Expects one of: 'foF2', 'hmF2', 'B0',
+        and 'B1'
+    irtam_dir : str
+        Directory for IRTAM coefficients, or '' to use package directory.
+        (default='')
+    use_subdirs : bool
+        If True, adds YYYY/MMDD subdirectories to the filename path, if False
+        assumes that the entire path to the coefficient directory is provided
+        by `irtam_dir` (default=True)
+    overwrite : bool
+        Allow overwriting of existing parameter files if True (default=False)
+
+    Returns
+    -------
+    dstat : bool
+        Download status: True if file was downloaded, False if not
+    fstat : bool
+        File status: True if parameter coefficient file exists, False if not
+    msg : str
+        Potential message with more details about status flags, empty if both
+        are True
+
+    Notes
+    -----
+    LGDC claims to also support 'VTEC', 'MUF3000', 'TAU', but tests for these
+    paramaters failed
+
+    """
+    # Initalize output
+    dstat = False
+    fstat = False
+    msg = ''
+
+    # If no directory is provided, use the package default
+    if irtam_dir == '':
+        irtam_dir = PyIRTAM.irtam_coeff_dir
+
+    # Determine the appropriate output filename
+    param_file = get_irtam_param_filename(dtime, param, irtam_dir)
+
+    # Ensure the desired output directory exists
+    dir_name, _ = os.path.split(param_file)
+
+    if not os.path.isdir(dir_name):
+        os.makedirs(dir_name)
+
+    # Test to see if the file exists already, if overwriting is not desired
+    if os.path.isfile(param_file):
+        fstat = True
+        msg = 'IRTAM parameter coefficient file exists: {:}'.format(param_file)
+        if not overwrite:
+            return dstat, fstat, msg
+
+    # Construct the query
+    base_url = "https://lgdc.uml.edu/rix/gambit-coeffs"
+    url = "".join([base_url, "?charName=", param, "&time=", dtime.strftime(
+        "%Y.%m.%dT%H:%M:%S")])
+
+    # Download the webpage
+    req = requests.get(url)
+
+    # Test to see if the data was retrieved successfully
+    if req.text.find('START_HEADER') < 0:
+        # No data was retrieved
+        msg = ''.join([msg, '' if len(msg) == 0 else '\n',
+                       'Bad IRTAM coefficient query: ', url,
+                       '\nRemote message: ', req.text])
+
+        return dstat, fstat, msg
+
+    # Write the new coefficients to the desired output file
+    dstat = True
+    fstat = True
+    with open(param_file, 'w') as fout:
+        fout.write(req.text)
+
+    return dstat, fstat, msg
+
+
+def get_irtam_param_filename(dtime, param, irtam_dir='', use_subdirs=True):
+    """Determine the filename for the desired IRTAM coefficients.
+
+    Parameters
+    ----------
+    dtime : dt.datetime
+        Date and time for the desired coefficents
+    param : str
+        Coefficient parameter to retrieve. Expects one of: 'foF2', 'hmF2', 'B0',
+        and 'B1'
+    irtam_dir : str
+        Directory for IRTAM coefficients, or '' to use package directory.
+        (default='')
+    use_subdirs : bool
+        If True, adds YYYY/MMDD subdirectories to the filename path, if False
+        assumes that the entire path to the coefficient directory is provided
+        by `irtam_dir` (default=True)
+
+    Returns
+    -------
+    filename : str
+        IRTAM coefficient filename with full directory path
+
+    """
+    # If no directory is provided, use the package default
+    if irtam_dir == '':
+        irtam_dir = PyIRTAM.irtam_coeff_dir
+
+    # Construct the desired filename
+    time_str = ''.join([dtime.strftime('%Y%m%d'), '_', dtime.strftime('%H%M%S'),
+                        '.ASC'])
+
+    # Update the parameter name
+    if param in ['B0', 'B1']:
+        param_name = ''.join([param, 'in'])
+    else:
+        param_name = param
+
+    # Construct file with or without year and month-day subdirectories
+    if use_subdirs:
+        filename = os.path.join(irtam_dir, dtime.strftime('%Y'),
+                                dtime.strftime('%m%d'),
+                                '_'.join(['IRTAM', param_name, 'COEFFS',
+                                          time_str]))
+    else:
+        filename = os.path.join(irtam_dir, '_'.join(['IRTAM', param_name,
+                                                     'COEFFS', time_str]))
+
+    return filename

--- a/PyIRTAM/lib.py
+++ b/PyIRTAM/lib.py
@@ -846,7 +846,7 @@ def Ramakrishnan_Rawer_function(NmF2, hmF2, B0, B1, h):
 
 
 def call_IRTAM_PyIRI(aUT, dtime, alon, alat, aalt, f2, f1, e_peak, es_peak,
-                     modip, TOV, coeff_dir, irtam_dir):
+                     modip, TOV, irtam_dir='', use_subdirs=True):
     """Update parameters and build EDP for IRTAM for one time frame.
 
     Parameters
@@ -896,10 +896,13 @@ def call_IRTAM_PyIRI(aUT, dtime, alon, alat, aalt, f2, f1, e_peak, es_peak,
         Modified dip angle in degrees.
     TOV : float
         Time of Validity in decimal hours. Use 24 if not known.
-    coeff_dir : str
-        Direction of IRI coefficients.
     irtam_dir : str
-        Direction of IRTAM coefficients.
+        Directory for IRTAM coefficients, or '' to use package directory.
+        (default='')
+    use_subdirs : bool
+        If True, adds YYYY/MMDD subdirectories to the filename path, if False
+        assumes that the entire path to the coefficient directory is provided
+        by `irtam_dir` (default=True)
 
     Returns
     -------
@@ -942,13 +945,8 @@ def call_IRTAM_PyIRI(aUT, dtime, alon, alat, aalt, f2, f1, e_peak, es_peak,
     it = np.where(aUT == UT)[0]
 
     # Find IRTAM parameters
-    IRTAM_f2 = IRTAM_density(dtime,
-                             alon,
-                             alat,
-                             modip,
-                             TOV,
-                             coeff_dir,
-                             irtam_dir)
+    IRTAM_f2 = IRTAM_density(dtime, alon, alat, modip, TOV, irtam_dir,
+                             use_subdirs)
 
     # Create empty arrays with needed shape for 1 time frame
     # to fill with updated values
@@ -1015,7 +1013,8 @@ def call_IRTAM_PyIRI(aUT, dtime, alon, alat, aalt, f2, f1, e_peak, es_peak,
     return F2_result, F1_result, E_result, Es_result, EDP_result
 
 
-def run_PyIRTAM(year, month, day, aUT, alon, alat, aalt, F107, irtam_dir):
+def run_PyIRTAM(year, month, day, aUT, alon, alat, aalt, F107, irtam_dir='',
+                use_subdirs=True):
     """Update parameters and build EDP for IRTAM for one time frame.
 
     Parameters
@@ -1038,7 +1037,12 @@ def run_PyIRTAM(year, month, day, aUT, alon, alat, aalt, F107, irtam_dir):
     F107 : float
         User provided F10.7 solar flux index in SFU.
     irtam_dir : str
-        Place where IRTAM coefficients are on user's local computer.
+        Directory with IRTAM coefficients, or '' to use package directory.
+        (default='')
+    use_subdirs : bool
+        If True, adds YYYY/MMDD subdirectories to the filename path, if False
+        assumes that the entire path to the coefficient directory is provided
+        by `irtam_dir` (default=True)
 
     Returns
     -------
@@ -1154,19 +1158,11 @@ def run_PyIRTAM(year, month, day, aUT, alon, alat, aalt, F107, irtam_dir):
         dtime = dt.datetime(year, month, day, hour, minute, 0)
 
         # Call PyIRTAM:
-        F2, F1, E, Es, EDP = call_IRTAM_PyIRI(aUT,
-                                              dtime,
-                                              alon,
-                                              alat,
-                                              aalt,
-                                              f2_b,
-                                              f1_b,
-                                              e_b,
-                                              es_b,
-                                              mag['modip'],
-                                              aUT[it],
-                                              PyIRI.coeff_dir,
-                                              irtam_dir)
+        F2, F1, E, Es, EDP = call_IRTAM_PyIRI(aUT, dtime, alon, alat, aalt,
+                                              f2_b, f1_b, e_b, es_b,
+                                              mag['modip'], aUT[it],
+                                              PyIRI.coeff_dir, irtam_dir,
+                                              use_subdirs=use_subdirs)
         # Save results.
         if it == 0:
             for key in F2:

--- a/PyIRTAM/tests/test_coeff.py
+++ b/PyIRTAM/tests/test_coeff.py
@@ -99,7 +99,11 @@ class TestCoeffDownload(object):
         self.package_irtam_dir = PyIRTAM.irtam_coeff_dir
         self.test_dir = os.path.join(os.path.split(PyIRTAM.irtam_coeff_dir)[0],
                                      "tests", "test_coeff")
-        self.out = None
+        self.param = "B0"
+        self.dstat = None
+        self.fstat = None
+        self.msg = None
+        self.test_file = ''
         return
 
     def teardown_method(self):
@@ -109,7 +113,196 @@ class TestCoeffDownload(object):
         if self.package_irtam_dir != PyIRTAM.irtam_coeff_dir:
             PyIRTAM.irtam_coeff_dir = self.package_irtam_dir
 
-        # Remove the test directory, if it exists HERE
+        # Remove the test directory/ies and file, if present
+        if os.path.isfile(self.test_file):
+            os.remove(self.test_file)
 
-        del self.dtime, self.out
+            # Remove extra files, if present
+            self.msg = os.path.dirname(self.test_file)
+            for self.fstat in os.listdir(self.msg):
+                os.remove(os.path.join(self.msg, self.fstat))
+
+            while self.msg != self.test_dir and len(self.msg) > len(
+                    self.test_dir):
+                os.rmdir(self.msg)
+                self.msg, _ = os.path.split(self.msg)
+
+        if os.path.isdir(self.test_dir):
+            os.rmdir(self.test_dir)
+
+        del self.dtime, self.package_irtam_dir, self.test_dir, self.dstat
+        del self.fstat, self.msg, self.param, self.test_file
+        return
+
+    def eval_downloaded_contents(self, use_subdirs=True):
+        """Evaluate the contents of the download directory.
+
+        Parameters
+        ----------
+        use_subdirs : bool
+            If True there should be subdirectories
+
+        """
+        # Test the subdirectory structure
+        if use_subdirs:
+            dirlist = os.listdir(self.test_dir)
+            assert len(
+                dirlist) == 1, "unexpected number of subdirs: {:}".format(
+                    dirlist)
+            assert dirlist[0].find(self.dtime.strftime(
+                "%Y")) == 0, "unexpected dir name: {:}".format(dirlist[0])
+
+            self.test_file = os.path.join(self.test_dir, dirlist[0])
+            dirlist = os.listdir(self.test_file)
+            assert len(
+                dirlist) == 1, "unexpected number of subdirs: {:}".format(
+                    dirlist)
+            assert dirlist[0].find(self.dtime.strftime(
+                "%m%d")) == 0, "unexpected dir name: {:}".format(dirlist[0])
+
+            # Set the test file directory
+            self.test_file = os.path.join(self.test_file, dirlist[0])
+        else:
+            # Set the test file directory
+            self.test_file = self.test_dir
+
+        # Test the downloaded file
+        dirlist = os.listdir(self.test_file)
+        self.test_file = os.path.join(self.test_file, dirlist[0])
+        assert len(dirlist) == 1, "unexpected number of files: {:}".format(
+            dirlist)
+        assert self.test_file.find(self.dtime.strftime(
+            self.param)) > 0, "unexpected filename: {:}".format(self.test_file)
+        assert os.path.isfile(self.test_file), "not a file: {:}".format(
+            self.test_file)
+        return
+
+    def test_download_w_subdir(self):
+        """Test successful download with subdirectories."""
+        # Download the desired file
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=True)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=True)
+
+        # Test the return status
+        assert self.dstat, "data not downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert len(self.msg) == 0, "unexpected message: {:}".format(self.msg)
+
+        return
+
+    def test_download_no_subdir(self):
+        """Test successful download without subdirectories."""
+        # Download the desired file
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=False)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=False)
+
+        # Test the return status
+        assert self.dstat, "data not downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert len(self.msg) == 0, "unexpected message: {:}".format(self.msg)
+        return
+
+    def test_download_overwrite(self):
+        """Test successful download with overwrite."""
+        # Download the desired file for the first time
+        self.test_download_no_subdir()
+
+        # Download the desired file for the second time
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=False,
+            overwrite=True)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=False)
+
+        # Test the return status
+        assert self.dstat, "data not downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert self.msg.find(
+            "Overwriting IRTAM param") >= 0, "unexpected message: {:}".format(
+                self.msg)
+        return
+
+    def test_download_no_overwrite(self):
+        """Test successful download with overwrite."""
+        # Download the desired file for the first time
+        self.test_download_no_subdir()
+
+        # Download the desired file for the second time
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=False,
+            overwrite=False)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=False)
+
+        # Test the return status
+        assert not self.dstat, "data downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert self.msg.find(
+            "coefficient file exists") > 0, "unexpected message: {:}".format(
+                self.msg)
+        return
+
+    def test_download_package_dir(self):
+        """Test successful download to the package directory."""
+        # Change the package directory name
+        PyIRTAM.irtam_coeff_dir = self.test_dir
+
+        # Download the desired file
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, use_subdirs=False)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=False)
+
+        # Test the return status
+        assert self.dstat, "data not downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert len(self.msg) == 0, "unexpected message: {:}".format(self.msg)
+        return
+
+    @pytest.mark.parametrize("good_param", ["foF2", "hmF2", "B0", "B1"])
+    def test_download_params(self, good_param):
+        """Test successful download with all supported parameters.
+
+        Parameters
+        ----------
+        good_param : str
+            The good parameter names
+
+        """
+        # Download the desired file
+        self.param = good_param
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=False)
+
+        # Test the directory and file status
+        self.eval_downloaded_contents(use_subdirs=False)
+
+        # Test the return status
+        assert self.dstat, "data not downloaded: {:}".format(self.msg)
+        assert self.fstat, "file not saved: {:}".format(self.msg)
+        assert len(self.msg) == 0, "unexpected message: {:}".format(self.msg)
+        return
+
+    def test_download_bad_param(self):
+        """Test download failure with an unsupported parameter."""
+        # Download the desired file
+        self.param = "badParam"
+        self.dstat, self.fstat, self.msg = PyIRTAM.coeff.download_irtam_coeffs(
+            self.dtime, self.param, irtam_dir=self.test_dir, use_subdirs=False)
+
+        # Test the return status
+        assert not self.dstat, "data downloaded: {:}".format(self.msg)
+        assert not self.fstat, "file saved: {:}".format(self.msg)
+        assert self.msg.find(
+            "Bad IRTAM coefficient") >= 0, "unexpected message: {:}".format(
+                self.msg)
         return

--- a/PyIRTAM/tests/test_coeff.py
+++ b/PyIRTAM/tests/test_coeff.py
@@ -156,7 +156,12 @@ class TestCoeffDownload(object):
 
         # Test the downloaded file
         dirlist = os.listdir(self.test_file)
-        self.test_file = os.path.join(self.test_file, dirlist[0])
+        try:
+            self.test_file = os.path.join(self.test_file, dirlist[0])
+        except IndexError:
+            raise RuntimeError('problem setting: ', self.test_file, ":",
+                               dirlist, ":", self.test_dir)
+
         assert len(dirlist) == 1, "unexpected number of files: {:}".format(
             dirlist)
         assert self.test_file.find(self.dtime.strftime(

--- a/PyIRTAM/tests/test_coeff.py
+++ b/PyIRTAM/tests/test_coeff.py
@@ -5,6 +5,7 @@
 import datetime as dt
 import os
 import pytest
+import shutil
 
 import PyIRTAM
 
@@ -114,21 +115,8 @@ class TestCoeffDownload(object):
             PyIRTAM.irtam_coeff_dir = self.package_irtam_dir
 
         # Remove the test directory/ies and file, if present
-        if os.path.isfile(self.test_file):
-            os.remove(self.test_file)
-
-            # Remove extra files, if present
-            self.msg = os.path.dirname(self.test_file)
-            for self.fstat in os.listdir(self.msg):
-                os.remove(os.path.join(self.msg, self.fstat))
-
-            while self.msg != self.test_dir and len(self.msg) > len(
-                    self.test_dir):
-                os.rmdir(self.msg)
-                self.msg, _ = os.path.split(self.msg)
-
         if os.path.isdir(self.test_dir):
-            os.rmdir(self.test_dir)
+            shutil.rmtree(self.test_dir)
 
         del self.dtime, self.package_irtam_dir, self.test_dir, self.dstat
         del self.fstat, self.msg, self.param, self.test_file

--- a/PyIRTAM/tests/test_coeff.py
+++ b/PyIRTAM/tests/test_coeff.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# --------------------------------------------------------
+"""Unit tests for PyIRTAM.coeff functions."""
+
+import datetime as dt
+import os
+import pytest
+
+import PyIRTAM
+
+
+class TestCoeffFilename(object):
+    """Test class for coefficient filename construction."""
+
+    def setup_method(self):
+        """Initialize all tests."""
+        self.dtime = dt.datetime(2021, 1, 1, 1, 1, 1)
+        self.out = None
+        return
+
+    def teardown_method(self):
+        """Tear down to clean the test environment."""
+
+        del self.dtime, self.out
+        return
+
+    @pytest.mark.parametrize("param", ["B0", "B1", "hmF2", "foF2", "bad"])
+    def test_get_itram_param_filename_with_subdirs(self, param):
+        """Test the creation of different parameter filenames with subdirs.
+
+        Parameters
+        ----------
+        param : str
+            Coefficient parameter
+
+        """
+
+        self.out = PyIRTAM.coeff.get_irtam_param_filename(self.dtime, param,
+                                                          use_subdirs=True)
+
+        assert self.out.find(param) >= 0, "parameter missing from filename"
+        assert self.out.find(PyIRTAM.irtam_coeff_dir) == 0, "missing root dir"
+
+        self.out, _ = os.path.split(self.out)
+        assert self.out.find(self.dtime.strftime("%Y")) > 0, "missing year dir"
+        assert self.out.find(
+            self.dtime.strftime("%m%d")) > 0, "missing month-day dir"
+        return
+
+    @pytest.mark.parametrize("param", ["B0", "B1", "hmF2", "foF2", "bad"])
+    def test_get_itram_param_filename_without_subdirs(self, param):
+        """Test the creation of different parameter filenames with subdirs.
+
+        Parameters
+        ----------
+        param : str
+            Coefficient parameter
+
+        """
+
+        self.out = PyIRTAM.coeff.get_irtam_param_filename(self.dtime, param,
+                                                          use_subdirs=False)
+
+        assert self.out.find(param) >= 0, "parameter missing from filename"
+        assert self.out.find(PyIRTAM.irtam_coeff_dir) == 0, "missing root dir"
+
+        self.out, _ = os.path.split(self.out)
+        assert self.out.find(self.dtime.strftime("%Y")) < 0, "has year dir"
+        assert self.out.find(
+            self.dtime.strftime("%m%d")) < 0, "has month-day dir"
+        return
+
+    @pytest.mark.parametrize("param", ["B0", "B1", "hmF2", "foF2", "bad"])
+    def test_get_itram_param_filename_irtamdir(self, param):
+        """Test the creation of different parameter filenames with subdirs.
+
+        Parameters
+        ----------
+        param : str
+            Coefficient parameter
+
+        """
+
+        self.out = PyIRTAM.coeff.get_irtam_param_filename(self.dtime, param,
+                                                          irtam_dir='test')
+
+        assert self.out.find(param) >= 0, "parameter missing from filename"
+        assert self.out.find(PyIRTAM.irtam_coeff_dir) < 0, "wrong root dir"
+        assert self.out.find("test") == 0, "missing root dir"
+        return
+
+
+class TestCoeffDownload(object):
+    """Test class for coefficient retrieval."""
+
+    def setup_method(self):
+        """Initialize all tests."""
+        self.dtime = dt.datetime(2021, 1, 1, 1, 1, 1)
+        self.package_irtam_dir = PyIRTAM.irtam_coeff_dir
+        self.test_dir = os.path.join(os.path.split(PyIRTAM.irtam_coeff_dir)[0],
+                                     "tests", "test_coeff")
+        self.out = None
+        return
+
+    def teardown_method(self):
+        """Tear down to clean the test environment."""
+
+        # Ensure the package directory is correct
+        if self.package_irtam_dir != PyIRTAM.irtam_coeff_dir:
+            PyIRTAM.irtam_coeff_dir = self.package_irtam_dir
+
+        # Remove the test directory, if it exists HERE
+
+        del self.dtime, self.out
+        return

--- a/PyIRTAM/tests/test_coeff.py
+++ b/PyIRTAM/tests/test_coeff.py
@@ -156,14 +156,10 @@ class TestCoeffDownload(object):
 
         # Test the downloaded file
         dirlist = os.listdir(self.test_file)
-        try:
-            self.test_file = os.path.join(self.test_file, dirlist[0])
-        except IndexError:
-            raise RuntimeError('problem setting: ', self.test_file, ":",
-                               dirlist, ":", self.test_dir)
-
         assert len(dirlist) == 1, "unexpected number of files: {:}".format(
             dirlist)
+
+        self.test_file = os.path.join(self.test_file, dirlist[0])
         assert self.test_file.find(self.dtime.strftime(
             self.param)) > 0, "unexpected filename: {:}".format(self.test_file)
         assert os.path.isfile(self.test_file), "not a file: {:}".format(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,5 +4,8 @@ Application Programming Interface
 =================================
 
 
-.. automodule:: PyIRTAM.main_library
+.. automodule:: PyIRTAM.lib
+    :members:
+
+.. automodule:: PyIRTAM.coeff
     :members:

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -12,7 +12,7 @@ The most recent citation can be found at `Zenodo
 <https://zenodo.org/>`_.  The examples here are from the first
 release.
 
-* Forsythe, V., et al. (2023).
+* Forsythe, V., et al. (2024).
   PyIRTAM: A New Module of PyIRI for IRTAM Coefficients,
   Space Weather.
 
@@ -21,11 +21,10 @@ release.
   @software{PyIRTAM,
     author       = {Forsythe, V. and
                     Burrell, A.G.},
-    title        = {ADD TITLE},
-    month        = MONTH,
-    year         = 2022,
+    title        = {victoriyaforsythe/PyIRTAM: v0.0.Xa (v0.0.Xa)},
+    year         = 2024,
     publisher    = {Zenodo},
-    version      = {v0.0.1},
-    doi          = {DOI},
-    url          = {URL}
+    version      = {v0.0.X},
+    doi          = {10.5281/zenodo.10844521},
+    url          = {https://github.com/victoriyaforsythe/PyIRTAM}
   }

--- a/docs/examples/ex_daily_parameters.rst
+++ b/docs/examples/ex_daily_parameters.rst
@@ -2,20 +2,18 @@ Example 1: Daily Ionospheric Parameters
 =======================================
 
 PyIRTAM can calculate daily ionospheric parameters for the user provided
-IRTAM coefficients and grid.
-The estimation of the parameters occurs simultaneously at all grid points
-and for all desired diurnal time frames. 
+IRTAM coefficients and grid. The estimation of the parameters occurs
+simultaneously at all grid points and for all desired diurnal time frames. 
 
 1. Import libraries:
 
 ::
 
-
+   import datetime as dt
    import numpy as np
    import PyIRI
    import PyIRTAM
    import PyIRI.main_library as ml
-   import PyIRTAM.main_library as il
    import PyIRI.plotting as plot
 
 2. Specify a year, a month, and a day:
@@ -26,6 +24,7 @@ and for all desired diurnal time frames.
    year = 2022
    month = 1
    day = 1
+   dtime = dt.datetime(year, month, day)
 
 3. Specify solar flux index F10.7 in SFU:
 
@@ -64,23 +63,38 @@ and for all desired diurnal time frames.
    alt_max = 700
    aalt = np.arange(alt_min, alt_max, alt_res)
    
-7. Specify a directory on your machine where IRTAM coefficients live:
+7. Specify a directory on your machine where IRTAM coefficients live. If you
+   don't want to specify this, PyIRTAM will create a directory within the
+   package as a default. This location can be found through the variable
+   ``PyIRTAM.irtam_coeff_dir``:
 
 ::
 
-   irtam_dir = '/Users/vmakarevich/Documents/Science_VF2/PyIRTAM/IRTAM/'
-   
-8. Run PyIRTAM:
+   irtam_dir = '~/Data/IRTAM_Coeffs/'  # Directory need not exist
+
+8. Download the IRTAM coefficients from the UMass Lowell data base. By default,
+   these will be stored in subdirectories that separate data by year and
+   month-day:
 
 ::
 
-   f2_iri, f1_iri, e_iri, es_iri, sun, mag, edp_iri, f2_irtam, f1_irtam, e_irtam, es_irtam, edp_irtam = il.run_PyIRTAM(year, month, day, aUT, alon, alat, aalt, F107, irtam_dir)
+   for param in ['B0', 'B1', 'hmF2', 'foF2']:
+       PyIRTAM.coeff.download_irtam_coeffs(dtime, param, irtam_dir=irtam_dir)
 
-9. Plot results and saved at given location:
+9. Run PyIRTAM:
 
 ::
 
-   save_plot_dir = '/Users/vmakarevich/Documents/Science_VF2/PyIRTAM/Fig/'
+   (f2_iri, f1_iri, e_iri, es_iri, sun, mag, edp_iri, f2_irtam, f1_irtam,
+    e_irtam, es_irtam, edp_irtam) = PyIRTAM.run_PyIRTAM(year, month, day, aUT,
+                                                        alon, alat, aalt, F107,
+                                                        irtam_dir=irtam_dir)
+
+10. Plot results and saved at given location, suggestion provided:
+
+::
+
+   save_plot_dir = '~/Plots/IRTAM/'  # Directory must exist
    
    UT_show = 10
    plot.PyIRI_plot_NmF2(f2, ahr, alon, alat, alon_2d, alat_2d, sun,
@@ -117,20 +131,20 @@ and for all desired diurnal time frames.
     :align: center
     :alt: Global distribution of hmF2 from PyIRTAM.
 
-10. Plot density time series for PyIRI and PyIRTAM at specified location:
+11. Plot density time series for PyIRI and PyIRTAM at specified location:
 
 ::
 
    lon_plot = 0
    lat_plot = 0
    
-   plot.PyIRI_plot_1location_diurnal_density(edp_iri, alon, alat, lon_plot, lat_plot,
-                                             aalt, aUT, save_plot_dir,
+   plot.PyIRI_plot_1location_diurnal_density(edp_iri, alon, alat, lon_plot,
+                                             lat_plot, aalt, aUT, save_plot_dir,
                                              plot_name='PyIRI_EDP_diurnal.pdf')
 
-   plot.PyIRI_plot_1location_diurnal_density(edp_irtam, alon, alat, lon_plot, lat_plot,
-                                             aalt, aUT, save_plot_dir,
-                                             plot_name='PyIRTAM_EDP_diurnal.pdf')
+   plot.PyIRI_plot_1location_diurnal_density(
+       edp_irtam, alon, alat, lon_plot, lat_plot, aalt, aUT, save_plot_dir,
+       plot_name='PyIRTAM_EDP_diurnal.pdf')
 
 .. image:: Figs/PyIRI_diurnal.pdf
     :width: 600px

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,9 +9,9 @@ Prerequisites
 PyIRTAM uses the Python modules included in the list below. This module
 officially supports Python 3.9+.
 
-1. fortranformat
-2. matplotlib
-3. numpy
+1. numpy
+2. PyIRI
+3. requests
 
 
 Installation Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,9 @@ keywords = [
   "modelling"
 ]
 dependencies = [
-  "fortranformat",
-  "matplotlib",
   "numpy",
   "pyiri",
   "requests",
-  "scipy"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "matplotlib",
   "numpy",
   "pyiri",
+  "requests",
   "scipy"
 ]
 


### PR DESCRIPTION
# Description

Addresses #18 by adding a function to download the IRTAM coefficients.  Also cleans up some of the main library functions by:
- Making use of subdirectories optional
- Creating a function for naming files, to reduce duplicate code
- Removing unused inputs for functions

Updates the documentation to include downloading coefficients in the example.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Added unit tests for the new functions.  @victoriyaforsythe please run the example in the documents and ensure it still works for you.

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
